### PR TITLE
Fix typo (Praser::Error to ParserError)

### DIFF
--- a/lib/irc_parser.rb
+++ b/lib/irc_parser.rb
@@ -9,7 +9,7 @@ module IRCParser
 
   def message(identifier, prefix = nil, params = nil)
     klass = Messages::ALL[identifier]
-    raise IRCParser::Parser::Error, "Message not recognized: #{message.inspect}" unless klass
+    raise IRCParser::ParserError, "Message not recognized: #{message.inspect}" unless klass
     obj = klass.new(prefix, params)
     yield obj if block_given?
     obj


### PR DESCRIPTION
```
irb(main):001:0> require 'irc_parser'
=> true
irb(main):003:0> IRCParser::Parser::Error
NameError: uninitialized constant IRCParser::Parser
irb(main):002:0> IRCParser::ParserError
=> IRCParser::ParserError
```
